### PR TITLE
fix: drop duplicate sdo:creator/publisher shapes from scheme profile

### DIFF
--- a/data/config/profiles.ttl
+++ b/data/config/profiles.ttl
@@ -94,24 +94,15 @@ prez:DefaultSchemeProfile a prof:Profile, sh:NodeShape, prez:ObjectProfile ;
         sh:nodeKind sh:IRI ;
         prez:simpleView true
     ] ;
-    # Issue #22 — sh:class prov:Agent makes the editor render the agent picker
-    # instead of a literal text input for creator/publisher. Existing vocabs
-    # use both dcterms:* and sdo:* predicates, so constrain both.
-    sh:property [
-        sh:path sdo:creator ;
-        sh:order 6 ;
-        sh:class prov:Agent ;
-        prez:simpleView true
-    ] ;
+    # Issue #22 / #28 — sh:class prov:Agent makes the editor render the
+    # agent picker instead of a literal text input for creator/publisher.
+    # GA vocab data consistently uses dcterms:* (not sdo:*), so only those
+    # shapes are declared. Listing both produced duplicate rows in the
+    # editor with the same `order` (issue #28). If a future vocab adopts
+    # sdo:creator/publisher, add those shapes back and use distinct orders.
     sh:property [
         sh:path dcterms:creator ;
         sh:order 6 ;
-        sh:class prov:Agent ;
-        prez:simpleView true
-    ] ;
-    sh:property [
-        sh:path sdo:publisher ;
-        sh:order 7 ;
         sh:class prov:Agent ;
         prez:simpleView true
     ] ;


### PR DESCRIPTION
Closes GA #28's "duplicate rows" symptom.

## What

The scheme profile listed both `sdo:creator/publisher` AND `dcterms:creator/publisher` with the same `sh:order`. Result: two side-by-side rows in the editor, one populated (the dcterms one, matching the data) and one empty.

GA vocab data consistently uses `dcterms:*`, so the `sdo:*` shapes never matched any real values — pure UI clutter.

## After

Only the `dcterms:*` shapes are declared. If a future vocab adopts `sdo:creator/publisher`, the shapes can be added back with distinct orders or via `sh:or` / `sh:union`.

## Depends on

Companion parent PR for the agent-picker dedup fix: [Kurrawong/prez-lite#widget-bug-fixes](https://github.com/Kurrawong/prez-lite/pulls). After it's deployed, "Add agent" will also work correctly when a value is already set.

## Test plan

- [ ] After deploy, open any vocab in edit mode — only one Creator row and one Publisher row.
- [ ] The single row shows the existing dcterms value (e.g. "Geoscience Australia").