### PR TITLE
feat: enumerate Data Themes vocab as sh:in for sdo:keywords (#26)

### DIFF
--- a/data/background/DataThemes.ttl
+++ b/data/background/DataThemes.ttl
@@ -1,0 +1,435 @@
+PREFIX : <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/>
+PREFIX DATAROLES: <https://linked.data.gov.au/def/data-roles/>
+PREFIX astatus: <https://linked.data.gov.au/def/reg-statuses/>
+PREFIX cs: <https://pid.geoscience.gov.au/def/voc/ga/DataThemes>
+PREFIX gavoc: <https://pid.geoscience.gov.au/def/voc/ga/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:administration
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "Related to the management of the duties and business of the organisation (Geoscience Australia), i.e. covering the work involved in planning, organising, directing, controlling and coordinating resources and operations. It includes management of internal day-to-day operations as well as the external-facing fulfillment of functions and responsibilities."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "administration"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "https://linked.data.gov.au/def/gswa-vocabulary-themes/administration"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:ambient_noise_tomography
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:altLabel "ANT"@en ;
+    skos:broader :seismology ;
+    skos:definition "Ambient noise tomography is a way to get a subsurface image by using an ambient noise source."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "ambient noise tomography"@en ;
+    schema:citation "Ambient noise tomography - SEG Wiki"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:data_acquisition
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :data_management ;
+    skos:definition "Data acquisition related to the systematic processes of gathering observations and measurements, and related analytical techniques and methodologies, including sample preparation techniques."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "data acquisition"@en ;
+    schema:citation "https://linked.data.gov.au/def/gswa-vocabulary-themes/data-acquisition"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:energy
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :resources ;
+    skos:definition "Related to the study, exploration for and exploitation of physical processes and natural concentrations of materials for the main purpose of power generation. Energy resources include (a) concentrations of solid and/or fluid, inorganic or fossilized organic materials naturally occurring on or in the Earth’s crust (e.g. non-renewable fossil fuels such as petroleum, and natural gases); (b) natural physical processes within the Earth’s crust, atmosphere and hydrosphere (i.e. renewable energy resources such as solar, wind, hydro, solar thermal, marine, geothermal) or human-controlled activities (e.g. bioenergy/biomass, energy storage); and (c) nuclear energy. Adapted from Glossary of geology (Neuendorf et. al., 2011, 5th edition revised)."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "energy"@en ;
+    schema:citation "https://linked.data.gov.au/def/gswa-vocabulary-themes/energy"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:geochronology
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :geology ;
+    skos:definition "Geochronology is a discipline of geoscience which measures the age of earth materials and provides the temporal framework in which other geoscience data can be interpreted in the context of Earth history."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "geochronology"@en ;
+    schema:citation "https://www.ga.gov.au/scientific-topics/disciplines/geochronology"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:geoinformatics
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:altLabel "geomatics"@en ;
+    skos:broader :information_management ;
+    skos:definition "Geoinformatics is a scientific field primarily within the domains of Computer Science and technical geography. It focuses on the programming of applications, spatial data structures, and the analysis of objects and space-time phenomena related to the surface and underneath of Earth and other celestial bodies. The field develops software and web services to model and analyse spatial data, serving the needs of geosciences and related scientific and engineering disciplines. The term is often used interchangeably with Geomatics, although they are not exactly same. The field of geomatics is a comprehensive discipline encompassing both geodesy and geoinformatics, thus offering a more extensive scope."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "geoinformatics"@en ;
+    schema:citation "https://en.wikipedia.org/wiki/Geoinformatics"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:geomorphology
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :physical_geography ;
+    skos:definition "Geomorphology is a branch of Earth science that focuses on the study of landforms, their origin, development, and classification. It examines the processes that shape the Earth’s surface, such as erosion, weathering, tectonic activity, and sedimentation."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "geomorphology"@en ;
+    schema:citation "https://physicalgeography.org/geomorphology/"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:legislation
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "Related to laws and regulations governing, controlling or affecting the business of the organization, including those the organization is tasked to implement and administer."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "legislation"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "https://linked.data.gov.au/def/gswa-vocabulary-themes/legislation"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:magnetotellurics
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :geophysics ;
+    skos:definition "Magnetotellurics (MT) is a passive geophysical method which uses natural time variations of the Earth's magnetic and electric fields to measure the electrical resistivity of the sub-surface."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "magnetotellurics"@en ;
+    schema:citation "https://www.ga.gov.au/scientific-topics/disciplines/magnetotellurics"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:marine_geoscience
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :geology ;
+    skos:definition "Marine geoscience encompasses marine geology, geophysics, and geochemistry. It involves the study of the rocks that make up the ocean floor, its morphology, the processes that have created, modified, and destroyed it, and the structures that lie beneath it."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "marine geoscience"@en ;
+    schema:citation "https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2021CN000144#:~:text=The%20marine%20geosciences%2C%20which%20encompass"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:minerals
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :resources ;
+    skos:definition "Related to the study, exploration for and exploitation of concentrations of natural inorganic or fossilized organic material occurring on or within the Earth’s crust, in sufficient quantity and quality to have reasonable prospects for economic extraction. Mineral resources are non-renewable and include metals (e.g. iron, copper, and aluminium), non-metals (e.g. salt, gypsum, clay, sand, phosphates), and rocks (e.g. dimension stones, basic raw materials)."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "minerals"@en ;
+    schema:citation "https://glossary.americangeosciences.org/term/resources"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:natural_hazards
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :physical_geography ;
+    skos:definition "A natural hazard is a natural event driven primarily by weather or geology (for example, flood, volcanic eruption, earthquake, tropical storm) that threatens people or has the potential to cause damage, destruction and/or death."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "natural hazard"@en ;
+    schema:citation "https://www.internetgeography.net/topics/what-are-natural-hazards/"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:palaeontology
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :geology ;
+    skos:definition "Palaeontology is the study of fossils and what they reveal about the history of our planet. In marine environments microfossils collected within in layers of sediment cores provide a rich source of information about the environmental history of an area."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "palaeontology"@en ;
+    schema:citation "https://www.ga.gov.au/scientific-topics/disciplines/palaeontology"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:petrophysics
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :geophysics ;
+    skos:definition "The study of the physical and chemical properties of rocks in relation to their interaction with fluids. A major application of petrophysics is in studying reservoirs for the hydrocarbon industry (especially the distribution of the pore system and its contained hydrocarbons and water)."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "petrophysics"@en ;
+    schema:citation "https://linked.data.gov.au/def/earthsci-for/petrophysics"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:radiometrics
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :geophysics ;
+    skos:definition "The radiometric, or gamma-ray spectrometric method is a geophysical process used to estimate concentrations of the radioelements: potassium, uranium and thorium in the near surface. This is done by measuring the gamma-rays which the radioactive isotopes of these elements emit during radioactive decay."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "radiometrics"@en ;
+    schema:citation "https://www.ga.gov.au/scientific-topics/disciplines/radiometrics"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:sample_acquisition
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :sample_acquisition_and_management ;
+    skos:definition "Sample acquisition is related to the collection/procurement, handling, tracking, storing, and retrieving of primary geoscience material (typically, but not exclusively, a rock, mineral, fossil or soil) collected in the field or from materials collected in the field (e.g. drillcore)"@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "sample acquisition"@en ;
+    schema:citation "https://linked.data.gov.au/def/gswa-vocabulary-themes/sample-acquisition-management"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:data_management
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :information_management ;
+    skos:definition "Data Management is the development, execution, and supervision of plans, policies, programs, and practices that deliver, control, protect, and enhance the value of data and information assets throughout their lifecycles. It encompasses a range of disciplines and processes that collectively enable organizations to derive meaningful insights, make informed decisions, and maintain compliance with regulatory standards."@en ;
+    skos:inScheme cs: ;
+    skos:narrower :data_acquisition ;
+    skos:prefLabel "data management"@en ;
+    schema:citation "https://dama.org/about-dama/what-is-data-management/"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:earth_observation
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "Earth Observation is the collection, analysis and presentation of information about planet Earth’s physical, chemical and biological systems via remote sensing technologies."@en ;
+    skos:inScheme cs: ;
+    skos:narrower :geodesy ;
+    skos:prefLabel "earth observation"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "https://www.gov.uk/government/collections/earth-observation-eo"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:geochemistry
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :geology ;
+    skos:definition "Geochemistry is the study of the distribution and amounts of the chemical elements in minerals, ores, rocks, soils, water, and the atmosphere, and the study of the circulation of the elements in nature, on the basis of the properties of their atoms and ions; also, the study of the distribution and abundance of isotopes, including problems of nuclear frequency and stability in the universe. A major concern of geochemistry is the synoptic evaluation of the abundances of the elements in the Earth's crust and in major classes of rocks and minerals."@en ;
+    skos:inScheme cs: ;
+    skos:narrower :hydrogeochemistry ;
+    skos:prefLabel "geochemistry"@en ;
+    schema:citation "https://glossary.americangeosciences.org/term/geochemistry"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:geodesy
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader
+        :earth_observation ,
+        :geophysics ;
+    skos:definition "Geodesy measures the size, shape, orientation and gravity field of our dynamic Earth and how it changes over time."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "geodesy"@en ;
+    schema:citation "https://www.ga.gov.au/scientific-topics/positioning-navigation/positioning-australia/geodesy"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:geography
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "Geography is the study of place, space, and the environment, and of people and others in relation to those."@en ;
+    skos:inScheme cs: ;
+    skos:narrower :physical_geography ;
+    skos:prefLabel "geography"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "https://www.iag.org.au/what-is-geography"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:hydrogeochemistry
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader
+        :geochemistry ,
+        :hydrology ;
+    skos:definition "The chemistry of ground and surface waters, particularly the relationships between the chemical characteristics and quality of waters and the areal and regional geology."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "hydrogeochemistry"@en ;
+    schema:citation "hydrogeochemistry | glossary.americangeosciences.org"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:hydrogeology
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader
+        :geology ,
+        :hydrology ;
+    skos:definition "Hydrogeology is defined as the study of groundwater, encompassing its origin, occurrence, movement, and quality, while also examining its interactions within the hydrologic cycle and its relationship with other water components like precipitation and streams."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "hydrogeology"@en ;
+    schema:citation "https://www.sciencedirect.com/topics/earth-and-planetary-sciences/hydrogeology"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:sample_acquisition_and_management
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "Sample acquisition and management is related to the collection/procurement, handling, tracking, storing, and retrieving of primary geoscience material (typically, but not exclusively, a rock, mineral, fossil or soil) collected in the field or from materials collected in the field (e.g. drillcore), as well as derived specimens from such materials for the purpose of analysis and research. Included are vocabularies related to collections as single entities."@en ;
+    skos:inScheme cs: ;
+    skos:narrower :sample_acquisition ;
+    skos:prefLabel "sample acquisition and management"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "https://linked.data.gov.au/def/gswa-vocabulary-themes/sample-acquisition-management"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:seismology
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :geophysics ;
+    skos:definition "Seismology is the scientific study of earthquakes (or generally, quakes) and the generation and propagation of elastic waves through planetary bodies. It also includes studies of the environmental effects of earthquakes such as tsunamis; other seismic sources such as volcanoes, plate tectonics, glaciers, rivers, oceanic microseisms, and the atmosphere; and artificial processes such as explosions."@en ;
+    skos:inScheme cs: ;
+    skos:narrower :ambient_noise_tomography ;
+    skos:prefLabel "seismology"@en ;
+    schema:citation "https://en.wikipedia.org/wiki/Seismology"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:hydrology
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "Hydrology is the science that encompasses the occurrence, distribution, movement and properties of the waters of the earth and their relationship with the environment within each phase of the hydrologic cycle. The water cycle, or hydrologic cycle, is a continuous process by which water is purified by evaporation and transported from the earth's surface (including the oceans) to the atmosphere and back to the land and oceans. All of the physical, chemical and biological processes involving water as it travels its various paths in the atmosphere, over and beneath the earth's surface and through growing plants, are of interest to those who study the hydrologic cycle."@en ;
+    skos:inScheme cs: ;
+    skos:narrower
+        :hydrogeochemistry ,
+        :hydrogeology ;
+    skos:prefLabel "hydrology"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "https://www.usgs.gov/water-science-school/science/what-hydrology#Hydrology"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:physical_geography
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :geography ;
+    skos:definition "Physical geography is the branch of natural science which deals with the processes and patterns in the natural environment such as the atmosphere, hydrosphere, biosphere, and geosphere."@en ;
+    skos:inScheme cs: ;
+    skos:narrower
+        :geomorphology ,
+        :natural_hazards ;
+    skos:prefLabel "physical geography"@en ;
+    schema:citation "https://en.wikipedia.org/wiki/Physical_geography"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:resources
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :geology ;
+    skos:definition "Concept related to the study, exploration for and exploitation of concentrations of solid, liquid, or gaseous materials in or on the Earth's crust in such form and amount that economic extraction of a commodity from the concentration is currently or potentially feasible. Adapted from Glossary of geology (Neuendorf et. al., 2011, 5th edition revised)."@en ;
+    skos:inScheme cs: ;
+    skos:narrower
+        :energy ,
+        :minerals ;
+    skos:prefLabel "resources"@en ;
+    schema:citation "https://linked.data.gov.au/def/gswa-vocabulary-themes/resources"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:information_management
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "The function of managing information as an enterprise resource, including planning, organising and staffing, and leading, directing, and controlling information."@en ;
+    skos:inScheme cs: ;
+    skos:narrower
+        :data_management ,
+        :geoinformatics ;
+    skos:prefLabel "information management"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "https://www.dama-uk.org/pages/glossary"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:geophysics
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :geology ;
+    skos:definition "Geophysics is the investigation of the solid and molten Earth using physical principles which allow studies on large scales and of the otherwise inaccessible deep Earth. Geophysical methods are used to study large scale Earth Structure, to measure the exact shape and size of the planet (Geodesy), to study the dynamics of the Earth’s interior and tectonic plates (Geodynamics), to study the history of Earth’s magnetic field and its present state (Geomagnetism), to study the physical properties of rocks and minerals at or near the surface, as well as those in the core (Mineral Physics), and finally, to study the physical causes and effects of earthquakes (Seismology)."@en ;
+    skos:inScheme cs: ;
+    skos:narrower
+        :geodesy ,
+        :magnetotellurics ,
+        :petrophysics ,
+        :radiometrics ,
+        :seismology ;
+    skos:prefLabel "geophysics"@en ;
+    schema:citation "https://www.sciencedirect.com/science/chapter/referencework/pii/B9780124095489053549#s0015"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:geology
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "Geology is the study of the materials of which the planet Earth is made, the processes that act on these materials, the products formed, and the history of the planet and its life forms since its origin."@en ;
+    skos:inScheme cs: ;
+    skos:narrower
+        :geochemistry ,
+        :geochronology ,
+        :geophysics ,
+        :hydrogeology ,
+        :marine_geoscience ,
+        :palaeontology ,
+        :resources ;
+    skos:prefLabel "geology"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "geology | glossary.americangeosciences.org"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+cs:
+    a skos:ConceptScheme ;
+    owl:versionIRI :1.0 ;
+    skos:definition "These geoscience data themes are used by Geoscience Australia to enable sorting of content in their registers."@en ;
+    skos:hasTopConcept
+        :administration ,
+        :earth_observation ,
+        :geography ,
+        :geology ,
+        :hydrology ,
+        :information_management ,
+        :legislation ,
+        :sample_acquisition_and_management ;
+    skos:historyNote """2026-05: Nested geochem and geophys under geology
+
+This vocabulary is a refresh of a previous GA data classification. The definitions have been sourced from other Australian Geological Surveys where possible. This was created for the purpose of grouping related vocabularies and other GA products to enable easy sorting by data type.""" ;
+    skos:prefLabel "GA Register Data Themes"@en ;
+    prov:qualifiedAttribution
+        [
+            prov:agent
+                [
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Smith M." ;
+                ] ;
+            prov:hadRole DATAROLES:custodian ;
+        ] ;
+    schema:creator
+        [
+            a schema:Organization ;
+            schema:name "Data Governance And Catalogue Team" ;
+            schema:parentOrganization <https://linked.data.gov.au/org/ga> ;
+            schema:url ""^^xsd:anyURI ;
+        ] ;
+    schema:dateCreated "2025-12-11"^^xsd:date ;
+    schema:dateModified "2026-05-15"^^xsd:date ;
+    schema:identifier "https://pid.geoscience.gov.au/dataset/ga/150902"^^gavoc:eCatID ;
+    schema:keywords :information_management ;
+    schema:publisher <https://linked.data.gov.au/org/ga> ;
+    schema:status astatus:experimental ;
+    schema:version "1" ;
+.

--- a/data/config/profiles.ttl
+++ b/data/config/profiles.ttl
@@ -114,13 +114,51 @@ prez:DefaultSchemeProfile a prof:Profile, sh:NodeShape, prez:ObjectProfile ;
     ] ;
     sh:property [ sh:path sdo:dateCreated ; sh:order 8 ; prez:simpleView true ] ;
     sh:property [ sh:path sdo:dateModified ; sh:order 9 ; prez:simpleView true ] ;
-    # Issue #18 — sdo:keywords values are IRIs (e.g. from the GA Data Themes vocab).
-    # sh:nodeKind sh:IRI triggers the IRI-input widget.
+    # Issue #26 — sdo:keywords values are picked from the GA Data Themes vocab
+    # (https://pid.geoscience.gov.au/def/voc/ga/DataThemes). The 31 concept IRIs
+    # are enumerated in sh:in so the editor renders a select dropdown. Labels
+    # for each option resolve from data/background/DataThemes.ttl (vendored
+    # alongside this file) via the standard labels.json pipeline.
+    #
+    # When DataThemes is updated upstream, refresh data/background/DataThemes.ttl
+    # and regenerate this sh:in list.
     sh:property [
         sh:path sdo:keywords ;
         sh:order 10 ;
-        sh:nodeKind sh:IRI ;
-        prez:simpleView true
+        prez:simpleView true ;
+        sh:in (
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/administration>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/ambient_noise_tomography>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/data_acquisition>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/data_management>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/earth_observation>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/energy>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/geochemistry>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/geochronology>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/geodesy>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/geography>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/geoinformatics>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/geology>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/geomorphology>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/geophysics>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/hydrogeochemistry>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/hydrogeology>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/hydrology>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/information_management>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/legislation>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/magnetotellurics>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/marine_geoscience>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/minerals>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/natural_hazards>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/palaeontology>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/petrophysics>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/physical_geography>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/radiometrics>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/resources>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/sample_acquisition>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/sample_acquisition_and_management>
+            <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/seismology>
+        )
     ] ;
     sh:property [ sh:path sdo:version ; sh:order 11 ; prez:simpleView true ] ;
     # Issue #18 — bibliographic citation for the vocabulary (string or URL).


### PR DESCRIPTION
Closes #26.

The Concept Scheme's \`sdo:keywords\` was an iri-input free-form widget — users had to paste full IRIs by hand. The Data Themes vocab has only 31 concepts, so an inline \`sh:in\` enumeration is the simplest path.

## What

- **Vendor** \`DataThemes.ttl\` into \`data/background/\` so the standard \`generate-labels\` pipeline produces prefLabel entries in \`labels.json\`.
- **Replace** \`sh:nodeKind sh:IRI\` on \`sdo:keywords\` with \`sh:in (...)\` over the 31 concept IRIs. The editor's existing select widget kicks in automatically.

Combined with the companion parent prez-lite PR (\`hjohns/iri-labels-in-select\`), the dropdown options render their human prefLabels ("administration", "geophysics", "sample acquisition and management", …) rather than the underscored slugs.

## Maintenance

When DataThemes is updated upstream, refresh \`data/background/DataThemes.ttl\` and regenerate the IRI list in the profile. At 31 entries the manual sync is trivial; a follow-up could automate it.

## Depends on

Parent prez-lite PR: https://github.com/Kurrawong/prez-lite/pulls — merge & deploy first so dropdown options show labels instead of slugs.

## Test plan

- [ ] Open any vocab in edit mode → click the **keywords** row → see a dropdown.
- [ ] Dropdown options show human-readable labels (e.g. "geophysics", not \`geophysics\`).
- [ ] Selecting a value adds it; "Add value" adds another row (multi-select via repeated single-selects).
- [ ] Saving produces TTL with the proper full IRI: \`sdo:keywords <https://pid.geoscience.gov.au/def/voc/ga/DataThemes/...>\`.