### PR TITLE
feat: add sdo:status shape to ConceptScheme profile so editor renders a selector

### DIFF
--- a/data/config/profiles.ttl
+++ b/data/config/profiles.ttl
@@ -88,6 +88,28 @@ prez:DefaultSchemeProfile a prof:Profile, sh:NodeShape, prez:ObjectProfile ;
             <https://linked.data.gov.au/def/reg-statuses/valid>
         )
     ] ;
+    # GA vocabs use sdo:status on the Concept Scheme (not reg:status). Without
+    # this shape the editor falls through to a plain IRI input. Match the
+    # Concept profile (which already constrains sdo:status the same way) so
+    # Scheme editors get the same dropdown UX.
+    sh:property [
+        sh:path sdo:status ;
+        sh:order 4 ;
+        prez:simpleView true ;
+        sh:in (
+            <https://linked.data.gov.au/def/reg-statuses/accepted>
+            <https://linked.data.gov.au/def/reg-statuses/deprecated>
+            <https://linked.data.gov.au/def/reg-statuses/experimental>
+            <https://linked.data.gov.au/def/reg-statuses/invalid>
+            <https://linked.data.gov.au/def/reg-statuses/notAccepted>
+            <https://linked.data.gov.au/def/reg-statuses/reserved>
+            <https://linked.data.gov.au/def/reg-statuses/retired>
+            <https://linked.data.gov.au/def/reg-statuses/stable>
+            <https://linked.data.gov.au/def/reg-statuses/submitted>
+            <https://linked.data.gov.au/def/reg-statuses/superseded>
+            <https://linked.data.gov.au/def/reg-statuses/valid>
+        )
+    ] ;
     sh:property [
         sh:path owl:versionIRI ;
         sh:order 5 ;


### PR DESCRIPTION
The Concept Scheme **Status** field in the editor renders as a plain IRI text input instead of a dropdown — even though the underlying value is always one of the [Reg Statuses](https://linked.data.gov.au/def/reg-statuses) IRIs and the matching field on Concepts already gives you a dropdown.

## Cause

The ConceptScheme profile constrains `reg:status` with `sh:in (…reg-statuses…)`. But GA vocab data consistently uses `sdo:status` (`https://schema.org/status`) for the scheme — confirmed 44 of 44 scheme TTLs use `sdo:status`, 0 use `reg:status`. With no shape on `sdo:status` the editor falls through to its default IRI input.

## Change

Add an `sdo:status` shape that mirrors the existing Concept profile entry (same `sh:in` enumeration, same slot). The widget dispatch now hits the `select` branch automatically — no parent prez-lite code change required.

The existing `reg:status` shape is **kept untouched** per request. Both share `sh:order 4` since they're semantic duplicates; only one will ever be populated per scheme.

## Test plan

- [ ] After merge + full deploy, open any vocab in edit mode on the deployed site.
- [ ] **Status** row in the scheme metadata renders as a dropdown of the 11 reg-statuses values (matching the Concept Status field).
- [ ] Existing scheme data (e.g. `https://linked.data.gov.au/def/reg-statuses/experimental`) appears pre-selected.
- [ ] Saving a different status writes the new IRI to `sdo:status` correctly.
